### PR TITLE
GHA does not use container

### DIFF
--- a/.github/workflows/tw_pywrap_e2e_showcase.yml
+++ b/.github/workflows/tw_pywrap_e2e_showcase.yml
@@ -68,8 +68,9 @@ jobs:
       - name: Create all entities on Tower from end-to-end
         run: |
           mamba init
+          cd tw_pywrap_e2e_showcase
           temp_file=$(mktemp -q)
           echo $GOOGLE_KEY | base64 -d > $temp_file
           export GOOGLE_KEY=$temp_file
 
-          tw-pywrap tw_pywrap_e2e_showcase/tw_pywrap_e2e_showcase.yml
+          tw-pywrap tw_pywrap_e2e_showcase.yml

--- a/.github/workflows/tw_pywrap_e2e_showcase.yml
+++ b/.github/workflows/tw_pywrap_e2e_showcase.yml
@@ -1,4 +1,5 @@
-name: Create all entities in Tower from end-to-end with tw_pywrap
+name: e2e-showcase
+run-name: Create all entities in Tower from end-to-end with tw_pywrap
 # This workflow can be triggered manually with GitHub actions workflow dispatch button.
 # It will automate the end-to-end creation all of the following entities in Nextflow Tower:
 # Organization

--- a/.github/workflows/tw_pywrap_e2e_showcase.yml
+++ b/.github/workflows/tw_pywrap_e2e_showcase.yml
@@ -16,11 +16,15 @@ run-name: Create all entities in Tower from end-to-end with tw_pywrap
 
 on:
   workflow_dispatch:
+
 jobs:
   tw_pywrap_e2e_showcase:
     name:
     if: github.repository == 'drpatelh/tw-pywrap-ci'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     env:
       TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
       TOWER_GITHUB_PASSWORD: ${{ secrets.TOWER_GITHUB_PASSWORD }}
@@ -48,25 +52,22 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          auto-update-conda: true
           environment-file: tw-pywrap/environment.yml
-          activate-environment: tw_pywrap
           miniforge-variant: Mambaforge
           miniforge-version: latest
+          python-version: "3.10"
+          activate-environment: tw_pywrap
           use-mamba: true
 
-      - name: Setup pip
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: "tw-pywrap/setup.py"
-
-      - name: Install tw-pywrap
+      - name: Install pip & tw-pywrap
         run: |
-          python -m pip install -e ./tw-pywrap
+          mamba install -y -c conda-forge pip
+          pip install -e ./tw-pywrap
 
       - name: Create all entities on Tower from end-to-end
         run: |
+          mamba init
           temp_file=$(mktemp -q)
           echo $GOOGLE_KEY | base64 -d > $temp_file
           export GOOGLE_KEY=$temp_file

--- a/.github/workflows/tw_pywrap_e2e_showcase.yml
+++ b/.github/workflows/tw_pywrap_e2e_showcase.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup pip
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install tw-pywrap

--- a/.github/workflows/tw_pywrap_e2e_showcase.yml
+++ b/.github/workflows/tw_pywrap_e2e_showcase.yml
@@ -1,17 +1,17 @@
 name: Create all entities in Tower from end-to-end with tw_pywrap
 # This workflow can be triggered manually with GitHub actions workflow dispatch button.
 # It will automate the end-to-end creation all of the following entities in Nextflow Tower:
-  # Organization
-  # Teams
-  # Workspaces
-  # Participants
-  # Credentials
-  # Secrets
-  # Compute Environments
-  # Actions
-  # Datasets
-  # Pipelines
-  # Launch
+# Organization
+# Teams
+# Workspaces
+# Participants
+# Credentials
+# Secrets
+# Compute Environments
+# Actions
+# Datasets
+# Pipelines
+# Launch
 
 on:
   workflow_dispatch:
@@ -20,8 +20,6 @@ jobs:
     name:
     if: github.repository == 'drpatelh/tw-pywrap-ci'
     runs-on: ubuntu-latest
-    container:
-      image: drpatelh/tw_pywrap:latest
     env:
       TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
       TOWER_GITHUB_PASSWORD: ${{ secrets.TOWER_GITHUB_PASSWORD }}
@@ -36,6 +34,34 @@ jobs:
     steps:
       - name: Check out source-code repository
         uses: actions/checkout@v3
+        with:
+          path: tw_pywrap_e2e_showcase
+
+      - name: Check out tw-pywrap repository
+        uses: actions/checkout@v3
+        with:
+          repository: ejseqera/tw-pywrap
+          ref: main # Latest version (for now)
+          path: tw-pywrap
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2.2.0
+        with:
+          environment-file: tw-pywrap/environment.yml
+          activate-environment: tw_pywrap
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+
+      - name: Setup pip
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+          cache: "pip"
+
+      - name: Install tw-pywrap
+        run: |
+          python -m pip install -e ./tw-pywrap
 
       - name: Create all entities on Tower from end-to-end
         run: |
@@ -43,6 +69,4 @@ jobs:
           echo $GOOGLE_KEY | base64 -d > $temp_file
           export GOOGLE_KEY=$temp_file
 
-          pip install git+https://github.com/ejseqera/tw-pywrap.git@main
-
-          tw-pywrap tw_pywrap_e2e_showcase.yml
+          tw-pywrap tw_pywrap_e2e_showcase/tw_pywrap_e2e_showcase.yml

--- a/.github/workflows/tw_pywrap_e2e_showcase.yml
+++ b/.github/workflows/tw_pywrap_e2e_showcase.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+          cache-dependency-path: "tw-pywrap/setup.py"
 
       - name: Install tw-pywrap
         run: |


### PR DESCRIPTION
Skipped the container because it kept causing problems. This just installs from a Conda env but the principle is the same, it will take longer because it needs to rebuild every time but will have fewer permission problems etc. Once it's published this will all get easier!

See [here](https://github.com/drpatelh/tw-pywrap-ci/actions/runs/5380355209/jobs/9762946437) for a successful run.